### PR TITLE
docs: reestruturação completa de OEs, CPs, RFs e RNs

### DIFF
--- a/docs/visao/dor_dod.md
+++ b/docs/visao/dor_dod.md
@@ -1,0 +1,53 @@
+# Definition of Ready e Definition of Done — VitalTech
+
+Este documento define os critérios acordados pela equipe para determinar quando uma User Story está **pronta para entrar em sprint** (DoR) e quando está **concluída** (DoD).
+
+---
+
+## Definition of Ready (DoR)
+
+Uma User Story só pode ser incluída em uma sprint quando **todos** os critérios abaixo forem cumpridos:
+
+### 1. Formato e Escrita
+- [ ] A US está escrita no formato: *"Como [persona], quero [ação], para que [benefício]"*
+- [ ] A persona está corretamente identificada (Gestor, Cuidador ou Membro da equipe multidisciplinar)
+
+### 2. Critérios de Aceitação
+- [ ] Pelo menos um critério de aceitação está definido no formato: *"Dado [contexto], quando [ação], então [resultado esperado]"*
+- [ ] Os critérios de aceitação são objetivamente verificáveis (não subjetivos)
+- [ ] Cenários de erro ou exceção relevantes foram mapeados nos critérios de aceitação
+
+### 3. Critério INVEST
+- [ ] **I — Independent:** a US pode ser desenvolvida sem bloquear ou ser bloqueada por outra (ou a dependência foi documentada e resolvida)
+- [ ] **N — Negotiable:** o escopo da US ainda pode ser ajustado com o cliente se necessário
+- [ ] **V — Valuable:** a US entrega valor claro e direto a uma das personas definidas
+- [ ] **E — Estimable:** a equipe consegue estimar o esforço necessário para desenvolvê-la
+- [ ] **S — Small:** a US cabe em uma sprint sem precisar ser dividida
+- [ ] **T — Testable:** os critérios de aceitação permitem verificar objetivamente se a US foi entregue
+
+### 4. Estimativa
+- [ ] A US foi estimada pela equipe (via critérios da Matriz de Priorização)
+- [ ] A estimativa é compatível com a capacidade da sprint
+
+### 5. Clareza e Dependências
+- [ ] A equipe não tem dúvidas abertas sobre o escopo da US
+- [ ] Dependências com outras USs foram identificadas e registradas
+- [ ] Não há dependências bloqueantes sem resolução
+
+### 6. Artefatos de Apoio (quando aplicável)
+- [ ] Protótipo ou wireframe da funcionalidade está disponível
+- [ ] Regras de negócio relacionadas à US foram verificadas (RN-01 a RN-04)
+
+---
+
+## Definition of Done (DoD)
+
+*(A ser preenchido pela equipe — próxima etapa)*
+
+---
+
+## Histórico de Revisão
+
+| Data | Versão | Descrição | Autor |
+| :---: | :---: | --- | --- |
+| 17/05/2026 | 1.0 | Criação do documento com o DoR definido para o projeto VitalTech. | Gustavo Xavier |

--- a/docs/visao/requisitos.md
+++ b/docs/visao/requisitos.md
@@ -41,6 +41,11 @@ As regras de negócio definem restrições e comportamentos impostos pelo contex
 | **RN-02** | Todo registro assistencial inserido em qualquer dispositivo da equipe deve ser consolidado em um único repositório de dados institucional, garantindo que a informação esteja disponível a todos os perfis autorizados e eliminando silos de informação. | Eliminação do retrabalho de dupla digitação |
 | **RN-03** | O histórico assistencial de um residente inativado não pode ser excluído do sistema. Todos os registros de saúde devem ser preservados por no mínimo 20 anos após a data do último atendimento, em conformidade com a Resolução CFM nº 1.821/2007 e com os requisitos de retenção de dados sensíveis estabelecidos pela LGPD (Lei nº 13.709/2018, Art. 11 e 16). | Obrigação legal |
 | **RN-04** | A ocorrência de queda com lesão ou tentativa de suicídio de um residente deve ser registrada no sistema com data, horário e responsável pelo lançamento, em conformidade com o item 6.2 da RDC ANVISA nº 283/2005, para subsidiar a notificação obrigatória à autoridade sanitária local. | RDC ANVISA 283/2005, Art. 6.2 |
+| **RN-05** | Nenhum formulário de registro assistencial pode ser submetido com campos obrigatórios em branco. O sistema deve impedir o salvamento e indicar ao usuário quais campos precisam ser preenchidos. | Integridade dos dados e padronização dos registros |
+| **RN-06** | Os valores inseridos nas aferições de sinais vitais devem ser validados contra intervalos clínicos de referência (ex.: PA sistólica entre 60–250 mmHg; temperatura entre 34–42°C; glicemia entre 20–600 mg/dL). Valores fora desses limites não podem ser salvos sem confirmação explícita do usuário. | Prevenção de erros de digitação clínica |
+| **RN-07** | Quando os valores registrados de sinais vitais estiverem fora dos parâmetros clínicos normais, o sistema deve sinalizar o registro com alerta visual, indicando a necessidade de avaliação pela equipe responsável. | Segurança clínica e apoio à tomada de decisão |
+| **RN-08** | Todo registro de administração de medicamento deve incluir o horário exato de administração e não pode ser salvo sem essa informação, garantindo o rastreamento preciso de dosagens e dos intervalos entre administrações. | Controle de dosagem e segurança farmacológica |
+| **RN-09** | Após o salvamento de qualquer registro assistencial, o sistema deve exibir confirmação visual ao usuário informando que os dados foram persistidos com sucesso, garantindo ciência do cuidador antes de prosseguir para o próximo atendimento. | Confiabilidade operacional em ambiente de alta rotatividade |
 
 ---
 
@@ -65,3 +70,13 @@ Os requisitos não funcionais definem as restrições, atributos de qualidade e 
 | **RNF13** | Desempenho na consulta ao histórico | A recuperação de dados no banco MySQL para listagem do histórico não deve ultrapassar 3 segundos em rede estável. | Desempenho / Eficiência |
 | **RNF14** | Desempenho na filtragem do histórico | O tempo de aplicação de filtros de datas em registros já carregados deve ser instantâneo (*client-side*). | Desempenho / Eficiência |
 | **RNF15** | Desempenho na sincronização | O envio de registros armazenados em lote (*Background Sync*) deve ocorrer de forma assíncrona, sem bloquear a interface de uso. | Desempenho / Eficiência |
+
+---
+
+## Histórico de Revisão
+
+| Data | Versão | Descrição | Autor |
+| :---: | :---: | --- | --- |
+| 03/04/2026 | 1.0 | Criação deste documento. | Gustavo Xavier |
+| 17/05/2026 | 1.1 | Reestruturação completa: redução de 30 para 16 RFs, adição das RNs (RN-01 a RN-04). | Gustavo Xavier |
+| 17/05/2026 | 1.2 | Adição de RN-05 a RN-09, convertidas de RFs antigos conforme feedback do professor. | Gustavo Xavier |

--- a/docs/visao/requisitos.md
+++ b/docs/visao/requisitos.md
@@ -1,122 +1,67 @@
 # REQUISITOS DE SOFTWARE
 
-**VitalTech - Requisitos Funcionais e Não Funcionais**
+## VitalTech — Requisitos Funcionais e Não Funcionais
 
-Este documento consolida a uma pré-lista de requisitos do VitalTech. Os requisitos funcionais são apresentados apenas pelo nome, seguindo o formato **verbo no infinitivo + objeto**. Os requisitos não funcionais apresentam **nome, descrição e classificação por URPS+ e Sommerville**.
-
----
-
-## 1. Lista de Requisitos Funcionais - RFs
-
-Os requisitos funcionais descrevem as funcionalidades que o sistema deve disponibilizar para apoiar o acompanhamento assistencial dos idosos.
-
-### Identificação e Acesso
-
-| Código | Nome do requisito |
-|---|---|
-| RF01 | Autenticar funcionários |
-| RF02 | Gerenciar perfis de acesso |
-| RF03 | Identificar idosos |
-| RF04 | Consultar dados do idoso |
-| RF05 | Manter área de acompanhamento do idoso |
-
-### Registros de Saúde
-
-| Código | Nome do requisito |
-|---|---|
-| RF06 | Registrar pressão arterial |
-| RF07 | Registrar frequência cardíaca |
-| RF08 | Registrar glicemia |
-| RF09 | Registrar temperatura |
-| RF10 | Registrar data e horário da aferição |
-| RF11 | Validar valores das aferições |
-| RF12 | Emitir alerta de aferições fora dos parâmetros definidos |
-
-### Rotinas Assistenciais
-
-| Código | Nome do requisito |
-|---|---|
-| RF13 | Registrar alimentação do idoso |
-| RF14 | Registrar hidratação do idoso |
-| RF15 | Registrar banho do idoso |
-| RF16 | Registrar necessidades básicas do idoso |
-| RF17 | Registrar aspecto da urina |
-| RF18 | Registrar aspecto das fezes |
-| RF19 | Registrar observações assistenciais |
-
-### Medicamentos
-
-| Código | Nome do requisito |
-|---|---|
-| RF20 | Consultar medicamentos previstos |
-| RF21 | Registrar tomada de medicamento |
-| RF22 | Registrar ausência de tomada de medicamento |
-| RF23 | Registrar horário do medicamento |
-| RF24 | Registrar observações sobre medicamentos |
-
-### Histórico e Consulta
-
-| Código | Nome do requisito |
-|---|---|
-| RF25 | Consultar histórico de aferições |
-| RF26 | Consultar histórico de rotinas assistenciais |
-| RF27 | Consultar histórico de medicamentos |
-| RF28 | Filtrar histórico por idoso |
-| RF29 | Filtrar histórico por período |
-| RF30 | Filtrar histórico por tipo de registro |
-| RF31 | Visualizar resumo assistencial do idoso |
-
-### Rastreabilidade e Validação
-
-| Código | Nome do requisito |
-|---|---|
-| RF32 | Registrar autoria dos lançamentos |
-| RF33 | Registrar data e horário dos lançamentos |
-| RF34 | Validar preenchimento obrigatório |
-| RF35 | Centralizar registros assistenciais |
-
-### Operação Sem Conexão e Sincronização
-
-| Código | Nome do requisito |
-|---|---|
-| RF36 | Registrar informações sem conexão |
-| RF37 | Armazenar registros localmente |
-| RF38 | Sincronizar registros assistenciais |
-| RF39 | Exibir status de sincronização |
-| RF40 | Preservar registros não sincronizados |
+Este documento consolida a lista de requisitos funcionais e não funcionais do VitalTech, além de sua matriz de rastreabilidade com as Características do Produto (CP). Os requisitos funcionais são apresentados no formato verbo no infinitivo + objeto. Os requisitos não funcionais incluem nome, descrição técnica e classificação segundo os modelos URPS+ e/ou Sommerville.
 
 ---
 
-## 2. Lista de Requisitos Não Funcionais - RNFs
+## 1. Relação de Requisitos Funcionais (RFs) com as Características do Produto (CP)
 
-Os requisitos não funcionais descrevem características de qualidade, restrições e condições de operação do sistema.
+A tabela abaixo apresenta os requisitos funcionais do VitalTech. Cada RF deriva de exatamente uma Característica do Produto (CP) e representa uma ação realizada pelo usuário.
 
-| Código | Nome | Descrição | Classificação |
-|---|---|---|---|
-| RNF01 | Usabilidade em tablets | A interface deve ser adequada ao uso em tablets, considerando interação por toque, leitura em telas móveis e organização visual compatível com a rotina dos funcionários. | URPS+: Usabilidade<br>Sommerville: Produto |
-| RNF02 | Redução de digitação manual | O sistema deve priorizar campos fechados, alternativas pré-definidas e perguntas de resposta rápida, como “sim” ou “não”, sempre que a informação registrada permitir esse formato. | URPS+: Usabilidade<br>Sommerville: Produto |
-| RNF03 | Linguagem compreensível | O sistema deve utilizar linguagem clara, objetiva e adequada à rotina assistencial dos funcionários da instituição. | URPS+: Usabilidade<br>Sommerville: Produto |
-| RNF04 | Aprendizado rápido | A interface deve favorecer o aprendizado rápido por novos funcionários, considerando a alta rotatividade da equipe. | URPS+: Usabilidade<br>Sommerville: Produto |
-| RNF05 | Preservação de registros offline | O sistema deve preservar os registros realizados sem conexão até que sejam disponibilizados com sucesso no repositório central. | URPS+: Confiabilidade<br>Sommerville: Produto |
-| RNF06 | Disponibilidade das funções essenciais | As funções essenciais de registro assistencial devem permanecer disponíveis durante períodos de indisponibilidade temporária da rede. | URPS+: Confiabilidade<br>Sommerville: Produto |
-| RNF07 | Controle de acesso | O sistema deve restringir o acesso às informações dos idosos apenas a usuários autorizados, conforme seus perfis de acesso. | URPS+: Segurança (+)<br>Sommerville: Produto |
-| RNF08 | Rastreabilidade dos registros | O sistema deve manter rastreabilidade das operações realizadas nos registros assistenciais, incluindo identificação do responsável, data e horário da operação. | URPS+: Auditabilidade (+)<br>Sommerville: Produto |
-| RNF09 | Capacidade operacional | O sistema deve comportar a operação com até 74 idosos, 70 funcionários e 35 cuidadores cadastrados, conforme a realidade operacional da instituição. | URPS+: Desempenho<br>Sommerville: Produto |
-| RNF10 | Organização do histórico | O histórico dos idosos deve ser apresentado de forma cronológica, organizada e compreensível para a equipe. | URPS+: Usabilidade<br>Sommerville: Produto |
-| RNF11 | Suportabilidade em dispositivos móveis | O sistema deve funcionar corretamente nos tablets adotados pela instituição, sendo compatível com navegadores modernos e sistemas operacionais móveis compatíveis com a infraestrutura definida para o projeto. | URPS+: Suportabilidade<br>Sommerville: Produto |
-| RNF12 | Desempenho no registro assistencial | O sistema deve carregar as telas principais de registro assistencial em até 2 segundos em pelo menos 95% das tentativas e salvar registros com conexão em até 2 segundos em pelo menos 95% das operações. | URPS+: Desempenho<br>Sommerville: Produto |
-| RNF13 | Desempenho no registro sem conexão | O sistema deve salvar registros assistenciais localmente em até 1 segundo em pelo menos 95% das operações durante períodos de indisponibilidade de conexão. | URPS+: Desempenho / Confiabilidade<br>Sommerville: Produto |
-| RNF14 | Desempenho na consulta ao histórico | O sistema deve exibir o histórico assistencial de um idoso em até 3 segundos em pelo menos 95% das consultas. | URPS+: Desempenho<br>Sommerville: Produto |
-| RNF15 | Desempenho na filtragem do histórico | O sistema deve aplicar filtros ao histórico assistencial em até 3 segundos em pelo menos 95% das consultas. | URPS+: Desempenho<br>Sommerville: Produto |
-| RNF16 | Desempenho na sincronização | O sistema deve disponibilizar no repositório central os registros feitos sem conexão em até 5 minutos após o restabelecimento da conexão, considerando um lote de até 100 registros pendentes. | URPS+: Desempenho / Confiabilidade<br>Sommerville: Produto |
-
-
+| Código | Requisito | CP | Justificativa |
+| :--- | :--- | :--- | :--- |
+| **RF01** | Cadastrar dados do residente | CP1 | Cria o perfil digital do residente, substituindo a ficha em papel. |
+| **RF02** | Editar dados pessoais e clínicos do residente | CP1 | Atualiza informações do residente conforme necessidade clínica ou administrativa. |
+| **RF03** | Inativar o cadastro do residente | CP1 | Remove o residente do fluxo operacional ativo sem excluir o histórico (soft delete). |
+| **RF04** | Registrar sinais vitais do residente | CP2 | Digitaliza a aferição periódica de saúde no ponto de cuidado. |
+| **RF05** | Registrar rotinas assistenciais do residente | CP2 | Documenta alimentação e higiene do residente, substituindo o formulário em papel. |
+| **RF06** | Registrar administração de medicamentos | CP2 | Documenta a medicação efetivamente administrada ao residente no turno. |
+| **RF07** | Registrar ocorrências clínicas do residente | CP2 | Registra eventos e intercorrências observados durante o cuidado a partir de lista padronizada. |
+| **RF08** | Autenticar usuário no sistema | CP3 | Controla o acesso ao sistema por meio de credenciais individuais. |
+| **RF09** | Encerrar sessão do usuário | CP3 | Garante a segurança do dispositivo compartilhado após o uso. |
+| **RF10** | Cadastrar usuário | CP4 | Permite ao gestor incluir novos membros da equipe no sistema. |
+| **RF11** | Atualizar dados cadastrais do usuário | CP4 | Mantém as informações da equipe atualizadas. |
+| **RF12** | Redefinir senha de acesso do usuário | CP4 | Permite ao gestor restaurar o acesso de um usuário que esqueceu a senha. |
+| **RF13** | Revogar acesso do usuário | CP4 | Bloqueia o acesso ao sistema em casos de desligamento da equipe. |
+| **RF14** | Consultar histórico de registros do residente | CP5 | Permite à equipe visualizar a evolução clínica cronológica do residente. |
+| **RF15** | Filtrar histórico por período | CP5 | Facilita a busca de registros em intervalos de tempo específicos. |
+| **RF16** | Visualizar resumo assistencial do residente | CP5 | Exibe visão consolidada do estado atual e recente do residente para apoio à decisão. |
 
 ---
 
-## Histórico de Revisão
+## 2. Regras de Negócio (RNs)
 
-| Data | Versão | Descrição | Autor |
-| :---: | :---: | --- | --- |
-| 11/05/2026 | 1.0 | Criação do documento para a seção de requisitos funcionais e não funcionais. | Enzo Menali |
-| 11/05/2026 | 1.1 | Inclusão do documento na seção Visão do Produto e Projeto do GitPages. | Enzo Menali |
+As regras de negócio definem restrições e comportamentos impostos pelo contexto operacional e legal da instituição, independentemente de ação direta do usuário.
+
+| Código | Regra de Negócio | Fundamento |
+| :--- | :--- | :--- |
+| **RN-01** | Todo registro assistencial deve poder ser realizado independentemente da disponibilidade de conexão com o servidor, sendo sincronizado automaticamente quando a conexão for restabelecida. | Infraestrutura de rede instável da instituição |
+| **RN-02** | Todo registro assistencial inserido em qualquer dispositivo da equipe deve ser consolidado em um único repositório de dados institucional, garantindo que a informação esteja disponível a todos os perfis autorizados e eliminando silos de informação. | Eliminação do retrabalho de dupla digitação |
+| **RN-03** | O histórico assistencial de um residente inativado não pode ser excluído do sistema. Todos os registros de saúde devem ser preservados por no mínimo 20 anos após a data do último atendimento, em conformidade com a Resolução CFM nº 1.821/2007 e com os requisitos de retenção de dados sensíveis estabelecidos pela LGPD (Lei nº 13.709/2018, Art. 11 e 16). | Obrigação legal |
+| **RN-04** | A ocorrência de queda com lesão ou tentativa de suicídio de um residente deve ser registrada no sistema com data, horário e responsável pelo lançamento, em conformidade com o item 6.2 da RDC ANVISA nº 283/2005, para subsidiar a notificação obrigatória à autoridade sanitária local. | RDC ANVISA 283/2005, Art. 6.2 |
+
+---
+
+## 3. Lista de Requisitos Não Funcionais (RNFs)
+
+Os requisitos não funcionais definem as restrições, atributos de qualidade e premissas arquiteturais do sistema. Eles foram classificados com base nos atributos do modelo **URPS+** (Usability, Reliability, Performance, Supportability) e/ou **Sommerville**.
+
+| Código | Nome do Requisito (RNF) | Descrição Técnica | Classificação (URPS+ / Sommerville) |
+| :--- | :--- | :--- | :--- |
+| **RNF01** | Suportabilidade em dispositivos móveis | O sistema deve operar de forma responsiva como PWA em navegadores de tablets e smartphones utilizados pela instituição. | Suportabilidade / Portabilidade |
+| **RNF02** | Redução de digitação manual | A interface deve priorizar formulários *touch-based*, com botões largos e seletores visuais, minimizando o uso do teclado virtual. | Usabilidade / Usabilidade |
+| **RNF03** | Linguagem compreensível | Os termos e alertas da interface devem refletir o vocabulário técnico e cotidiano utilizado pelos cuidadores do asilo. | Usabilidade / Usabilidade |
+| **RNF04** | Aprendizado rápido | A navegação do sistema deve ser intuitiva, permitindo que um cuidador sem familiaridade tecnológica conclua um registro após breve treinamento. | Usabilidade / Usabilidade |
+| **RNF05** | Preservação de registros offline | O sistema deve reter os dados assistenciais na memória do navegador (IndexedDB) de forma íntegra em caso de queda de rede local. | Confiabilidade / Confiabilidade |
+| **RNF06** | Disponibilidade das funções essenciais | Os módulos de registro (sinais vitais, rotinas e higiene) devem estar integralmente disponíveis na ausência de conexão. | Confiabilidade / Disponibilidade |
+| **RNF07** | Controle de acesso | O sistema deve segregar as visões e permissões do sistema entre perfis de Cuidador, Equipe Multidisciplinar e Gestor. | Segurança (+) / Segurança |
+| **RNF08** | Rastreabilidade dos registros | Todos os registros críticos devem possuir *logs* inalteráveis de autoria e *timestamp* para auditoria técnica e resguardo legal. | Segurança (+) / Segurança |
+| **RNF09** | Capacidade operacional | A base de dados local e o banco principal devem suportar o volume diário de lançamentos gerados pelos cuidadores ativos em um turno. | Desempenho / Eficiência |
+| **RNF10** | Organização lógica do histórico | Os dados cronológicos de saúde devem ser dispostos de maneira padronizada, permitindo leitura rápida durante a passagem de plantão. | Usabilidade / Usabilidade |
+| **RNF11** | Desempenho no registro assistencial | O tempo entre o clique de "Salvar" e a persistência local (IndexedDB) não deve ultrapassar 1 segundo. | Desempenho / Eficiência |
+| **RNF12** | Desempenho no registro sem conexão | A operação da interface não deve apresentar travamentos na transição do estado *Online* para *Offline*. | Desempenho / Eficiência |
+| **RNF13** | Desempenho na consulta ao histórico | A recuperação de dados no banco MySQL para listagem do histórico não deve ultrapassar 3 segundos em rede estável. | Desempenho / Eficiência |
+| **RNF14** | Desempenho na filtragem do histórico | O tempo de aplicação de filtros de datas em registros já carregados deve ser instantâneo (*client-side*). | Desempenho / Eficiência |
+| **RNF15** | Desempenho na sincronização | O envio de registros armazenados em lote (*Background Sync*) deve ocorrer de forma assíncrona, sem bloquear a interface de uso. | Desempenho / Eficiência |

--- a/docs/visao/requisitos_storymap.md
+++ b/docs/visao/requisitos_storymap.md
@@ -1,0 +1,218 @@
+# Requisitos (RF/RNF) e Story Mapping — VitalTech
+
+Este documento deriva requisitos a partir de:
+- **Solução proposta reformulada**: `temp_solucao_proposta.md` (CP1–CP6 + OE1–OE5)
+- **Ata/notes do cliente**: `Instituto Lar dos Velhinhos - Sobradinho.md`
+
+## Premissas e escopo
+- Produto: **PWA offline-first** para tablets/smartphones, voltado ao **registro assistencial** e consulta de histórico.
+- Contexto: **74 residentes**, ~**35 cuidadores**, **rede instável**, **servidor local** e legado em **Microsoft Access**.
+- Perfis (mínimo): **Cuidador/Equipe** (registro e consulta) e **Administrador/Diretoria** (gestão de acesso e cadastros base).
+
+---
+
+## Personas → Objetivos → Objetivos (macro) → Requisitos
+
+Este encadeamento é o que você pode usar no board: **objetivos (da persona)** derivam em **objetivos (macro)** e cada objetivo (macro) referencia os **RFs** (e os **RNFs** que impactam a qualidade).
+
+### Persona 1 — Cuidador(a) (usuário primário)
+
+**Objetivo P1.O1 — Registrar atendimento com rapidez e baixa chance de erro**
+- **Objetivos (macro)**: Acessar e identificar; Selecionar residente; Registrar rotina assistencial
+- **Requisitos (RF)**: RF-01, RF-02, RF-03, RF-05, RF-06, RF-07, RF-08, RF-09, RF-10, RF-11, RF-12, RF-13
+- **Requisitos (RNF)**: RNF-01, RNF-07, RNF-04
+
+**Objetivo P1.O2 — Continuar trabalhando sem internet e sem retrabalho**
+- **Objetivos (macro)**: Operar offline e sincronizar
+- **Requisitos (RF)**: RF-16, RF-17, RF-18
+- **Requisitos (RNF)**: RNF-02, RNF-03
+
+**Objetivo P1.O3 — Consultar histórico para orientar o cuidado no plantão**
+- **Objetivos (macro)**: Selecionar residente; Consultar histórico
+- **Requisitos (RF)**: RF-05, RF-06, RF-07, RF-14, RF-15
+- **Requisitos (RNF)**: RNF-04, RNF-05
+
+**Objetivo P1.O4 (opcional/pós-MVP) — Registrar administração de medicamentos**
+- **Objetivos (macro)**: Registrar rotina assistencial (medicação)
+- **Requisitos (RF)**: RF-22
+- **Requisitos (RNF)**: RNF-01, RNF-07
+
+### Persona 2 — Equipe multidisciplinar (consulta e tomada de decisão)
+
+**Objetivo P2.O1 — Acessar rapidamente o histórico do residente para tomada de decisão**
+- **Objetivos (macro)**: Acessar e identificar; Selecionar residente; Consultar histórico
+- **Requisitos (RF)**: RF-01, RF-02, RF-05, RF-06, RF-07, RF-14, RF-15
+- **Requisitos (RNF)**: RNF-04, RNF-05
+
+**Objetivo P2.O2 — Confiar na rastreabilidade dos registros (autoria e tempo)**
+- **Objetivos (macro)**: Consultar histórico
+- **Requisitos (RF)**: RF-03, RF-15
+- **Requisitos (RNF)**: RNF-10, RNF-06
+
+### Persona 3 — Diretoria/Admin (governança e conformidade)
+
+**Objetivo P3.O1 — Garantir controle de acesso e responsabilidade por ações**
+- **Objetivos (macro)**: Acessar e identificar
+- **Requisitos (RF)**: RF-01, RF-02, RF-03, RF-04
+- **Requisitos (RNF)**: RNF-05, RNF-10
+
+**Objetivo P3.O2 — Centralizar dados para eliminar dupla digitação e permitir histórico único**
+- **Objetivos (macro)**: Operar offline e sincronizar
+- **Requisitos (RF)**: RF-17, RF-19, RF-20, RF-21
+- **Requisitos (RNF)**: RNF-02, RNF-03, RNF-07, RNF-09
+
+**Objetivo P3.O3 — Atender exigências de privacidade e auditoria (LGPD)**
+- **Objetivos (macro)**: Acessar e identificar; Operar offline e sincronizar; Consultar histórico
+- **Requisitos (RF)**: RF-03, RF-04, RF-19, RF-21
+- **Requisitos (RNF)**: RNF-06, RNF-05, RNF-10
+
+---
+
+## Requisitos Funcionais (RF)
+
+Lista de RFs no padrão solicitado: **verbo no infinitivo + objeto** (somente o nome do requisito).
+
+| ID | Requisito Funcional |
+| --- | --- |
+| **RF-01** | Autenticar usuário |
+| **RF-02** | Encerrar sessão |
+| **RF-03** | Registrar autoria do registro |
+| **RF-04** | Gerenciar perfis de acesso |
+| **RF-05** | Listar residentes |
+| **RF-06** | Buscar residente |
+| **RF-07** | Selecionar residente |
+| **RF-08** | Identificar residente por ID |
+| **RF-09** | Registrar sinais vitais |
+| **RF-10** | Registrar alimentação e hidratação |
+| **RF-11** | Registrar higiene e necessidades básicas |
+| **RF-12** | Registrar aspecto de urina e fezes |
+| **RF-13** | Preencher formulário por seleção rápida |
+| **RF-14** | Consultar histórico do residente |
+| **RF-15** | Visualizar detalhes do registro |
+| **RF-16** | Registrar dados offline |
+| **RF-17** | Sincronizar registros automaticamente |
+| **RF-18** | Indicar status de sincronização |
+| **RF-19** | Receber registros via API |
+| **RF-20** | Armazenar registros em repositório central |
+| **RF-21** | Validar registros no servidor |
+| **RF-22** | Registrar administração de medicação |
+
+---
+
+## Requisitos Não Funcionais (RNF)
+
+Lista de RNFs no padrão solicitado: **nome + descrição + classificação** (URPS+ e Sommerville).
+
+| ID | Nome | Descrição do requisito | Classificação (URPS+) | Classificação (Sommerville) |
+| --- | --- | --- | --- | --- |
+| **RNF-01** | Garantir interface click-based | A interface deve ser predominantemente baseada em seleção (sim/não, listas e botões grandes), minimizando digitação e reduzindo tempo de treinamento para novos cuidadores. | **U** (Usability) | **Produto** |
+| **RNF-02** | Garantir operação offline | O sistema deve permitir o registro assistencial durante indisponibilidade de rede (sem internet) durante o turno, sem impedir o fluxo de trabalho. | **R** (Reliability) | **Produto** |
+| **RNF-03** | Garantir persistência local durável | Registros feitos offline devem permanecer armazenados localmente mesmo em caso de fechamento do app, queda de energia ou reinício do dispositivo, até sincronização bem-sucedida. | **R** (Reliability) | **Produto** |
+| **RNF-04** | Garantir desempenho de navegação | A listagem e busca de residentes deve manter resposta fluida no tablet considerando o universo de ~74 residentes. | **P** (Performance) | **Produto** |
+| **RNF-05** | Garantir autenticação e autorização | O acesso ao sistema e aos endpoints da API deve exigir autenticação; ações sensíveis devem respeitar permissões por perfil (ex.: gestão de acesso restrita). | **+ Segurança** | **Produto** |
+| **RNF-06** | Garantir conformidade com LGPD | O sistema deve restringir acesso a dados sensíveis, registrar auditoria de acesso/alteração e reduzir exposição de dados em telas e logs, visando aderência à LGPD. | **+ Segurança/Legal** | **Externo** |
+| **RNF-07** | Garantir integridade dos registros | O sistema deve aplicar validações de campos obrigatórios, formatos/unidades e consistência mínima para reduzir registros inválidos e aumentar confiabilidade da informação. | **R** (Reliability) | **Produto** |
+| **RNF-08** | Garantir compatibilidade PWA | O frontend deve operar como PWA em navegadores modernos de tablets/smartphones, com interface responsiva e capacidade de operação offline-first. | **+ Compatibilidade** | **Produto** |
+| **RNF-09** | Garantir manutenibilidade | A solução deve priorizar simplicidade de código e arquitetura, facilitando manutenção futura (ex.: organização clara, baixa complexidade e documentação mínima). | **S** (Supportability) | **Produto** |
+| **RNF-10** | Garantir auditabilidade | Cada registro assistencial deve permitir rastreabilidade de autoria e timestamp (quem fez o quê e quando) para auditorias internas. | **+ Segurança/Compliance** | **Produto** |
+
+---
+
+## Story Map (texto curto para colar no FigJam)
+
+Abaixo está uma proposta de “stickies” em três níveis típicos de story mapping:
+- **Objetivos (macro)**
+- **Atividades (tarefas)**
+- **User stories (itens implementáveis)**
+
+> Dica: no FigJam, use os títulos como stickies; mantenha o ID (RF/RNF) no início para rastrear.
+
+### Objetivo A — Acessar e identificar
+**Atividades**
+- Login
+- Logout
+- Troca de usuário/turno
+
+**User stories**
+- **RF-01** Como cuidador, quero fazer login, para que meus registros fiquem identificados.
+- **RF-02** Como cuidador, quero sair da minha conta, para evitar uso indevido no próximo turno.
+- **RF-03** Como diretoria, quero saber quem registrou cada dado, para garantir rastreabilidade.
+
+**Qualidade (RNF)**
+- **RNF-05** Autenticação obrigatória para acessar dados.
+- **RNF-10** Trilha de auditoria por registro.
+
+### Objetivo B — Selecionar residente
+**Atividades**
+- Ver lista por setor/quarto
+- Buscar por nome
+- Abrir prontuário do residente
+
+**User stories**
+- **RF-05** Como cuidador, quero ver a lista de residentes por setor/quarto, para achar rápido quem vou atender.
+- **RF-06** Como cuidador, quero buscar residente pelo nome, para não perder tempo no plantão.
+- **RF-07** Como cuidador, quero selecionar um residente e abrir seu prontuário, para registrar o atendimento.
+- **RF-08** Como cuidador, quero ver um ID do residente, para evitar confusão entre nomes parecidos.
+
+**Qualidade (RNF)**
+- **RNF-04** Busca fluida para 74 residentes.
+
+### Objetivo C — Registrar rotina assistencial
+**Atividades**
+- Registrar sinais vitais
+- Registrar alimentação/hidratação
+- Registrar higiene/necessidades
+- Registrar urina/fezes
+
+**User stories**
+- **RF-09** Como cuidador, quero registrar PA/FC/glicemia/temperatura, para documentar o estado do residente.
+- **RF-10** Como cuidador, quero registrar alimentação/hidratação, para acompanhar necessidades básicas.
+- **RF-11** Como cuidador, quero registrar banho/higiene e necessidades, para manter histórico assistencial.
+- **RF-12** Como cuidador, quero registrar aspecto de urina/fezes por opções, para padronizar o registro.
+- **RF-13** Como cuidador, quero preencher por seleção rápida (botões e sim/não), para registrar rápido sem digitar.
+
+**Qualidade (RNF)**
+- **RNF-01** Interface click-based e treinamento rápido.
+- **RNF-07** Campos obrigatórios e formatos consistentes.
+
+### Objetivo D — Consultar histórico
+**Atividades**
+- Ver histórico cronológico
+- Abrir detalhe do registro
+
+**User stories**
+- **RF-14** Como equipe multidisciplinar, quero ver o histórico do residente, para tomar decisão com base no último atendimento.
+- **RF-15** Como equipe, quero abrir um registro do histórico, para ver valores e autoria.
+
+### Objetivo E — Operar offline e sincronizar
+**Atividades**
+- Registrar offline
+- Sincronizar quando voltar rede
+- Ver estado da sincronização
+
+**User stories**
+- **RF-16** Como cuidador, quero registrar dados sem internet, para não parar o atendimento.
+- **RF-17** Como cuidador, quero que os dados sincronizem automaticamente, para não ter retrabalho.
+- **RF-18** Como cuidador, quero ver se algo ficou pendente/erro, para garantir que nada foi perdido.
+- **RF-19** Como sistema, quero enviar registros para uma API autenticada, para centralizar as informações.
+- **RF-20** Como diretoria, quero dados centralizados, para reduzir dupla digitação e permitir histórico único.
+- **RF-21** Como sistema, quero validar registros no servidor, para evitar dados inválidos.
+
+**Qualidade (RNF)**
+- **RNF-02** Operação offline durante turno.
+- **RNF-03** Persistência local durável.
+
+### Objetivo F (opcional / pós-MVP) — Medicação
+**Atividades**
+- Registrar horários
+- Marcar tomou/não tomou
+
+**User stories**
+- **RF-22** Como cuidador, quero registrar se o residente tomou o medicamento no horário, para reduzir falhas no cuidado.
+
+---
+
+## Corte sugerido por release (se o template tiver fatias MVP)
+- **MVP**: RF-01, RF-03, RF-05–07, RF-09–11, RF-13–14, RF-16–17, RF-19–20
+- **Release 2**: RF-08, RF-12, RF-15, RF-18, RF-21
+- **Release 3 (opcional)**: RF-22 (medicação)

--- a/docs/visao/solucao_proposta.md
+++ b/docs/visao/solucao_proposta.md
@@ -6,11 +6,11 @@ Digitalizar a gestão assistencial do Lar dos Velhinhos Bezerra de Menezes.
 ## 2.2 Objetivos Específicos (OE) do Produto
 Para alcançar o objetivo geral, o desenvolvimento do VitalTech baseia-se nos seguintes objetivos específicos:
 
-* **(OE1)** Centralizar o registro assistencial dos residentes em formato digital. *(foco: substituição do papel)*
+* **(OE1)** Centralizar o registro assistencial dos residentes. *(foco: substituição do papel)*
 
 * **(OE2)** Garantir o controle de acesso e a rastreabilidade das ações da equipe. *(foco: segurança / auditoria)*
 
-* **(OE3)** Apoiar a tomada de decisão clínica com acesso ao histórico do residente. *(foco: consulta / decisão)*
+* **(OE3)** Apoiar a tomada de decisão clínica. *(foco: consulta / decisão)*
 
 ## 2.3 Características de Produto
 *(mapeadas com os Objetivos Específicos do Produto)*

--- a/docs/visao/solucao_proposta.md
+++ b/docs/visao/solucao_proposta.md
@@ -1,30 +1,27 @@
 # 2. Solução Proposta
 
 ## 2.1 Objetivo Geral do Produto
-Desenvolver uma solução digital para apoiar o registro e o acompanhamento da rotina assistencial dos idosos do Lar dos Velhinhos, reduzindo o retrabalho manual e ampliando a rastreabilidade das informações de cuidado.
+Digitalizar a gestão assistencial do Lar dos Velhinhos Bezerra de Menezes.
 
 ## 2.2 Objetivos Específicos (OE) do Produto
-Para alcançar o objetivo geral e enfrentar a inviabilidade do monitoramento preventivo gerada pelo fluxo manual, o desenvolvimento do Vital Tech baseia-se nos seguintes objetivos específicos:
+Para alcançar o objetivo geral, o desenvolvimento do VitalTech baseia-se nos seguintes objetivos específicos:
 
-* **(OE1)** Reduzir a dependência de registros em papel no acompanhamento de sinais vitais e rotinas de saúde dos idosos. 
+* **(OE1)** Centralizar o registro assistencial dos residentes em formato digital. *(foco: substituição do papel)*
 
-* **(OE2)** Eliminar o retrabalho e a dupla digitação dos registros assistenciais realizados pela equipe. 
-* **(OE3)** Garantir a continuidade da operação assistencial independente da infraestrutura de rede.
-* **(OE4)** Reduzir a incidência de erros humanos e o tempo de preenchimento mitigando os impactos da alta rotatividade de funcionários.
+* **(OE2)** Garantir o controle de acesso e a rastreabilidade das ações da equipe. *(foco: segurança / auditoria)*
 
-* **(OE5)** Facilitar o acesso ao histórico cronológico das aferições e rotinas de saúde dos idosos, apoiando a tomada de decisão da equipe multidisciplinar. 
+* **(OE3)** Apoiar a tomada de decisão clínica com acesso ao histórico do residente. *(foco: consulta / decisão)*
 
 ## 2.3 Características de Produto
 *(mapeadas com os Objetivos Específicos do Produto)*
 
-| ID | Característica do Produto (CP) | Descrição resumida | Valor de Negócio (VN) Principal | Contribuição Principal | Contribuição Secundária |
-| --- | --- | --- | --- | --- | --- |
-| **CP1** | Gestão de Acesso e Autenticação de Usuários | Capacidade do sistema de identificar, autenticar e registrar qual membro da equipe realizou cada interação, garantindo rastreabilidade de autorias por turno e perfil de acesso. | Segurança e rastreabilidade de quem inseriu ou alterou cada dado assistencial. | OE2 | OE4 |
-| **CP2** | Painel de Seleção e Gerenciamento de Residentes | Capacidade de listar, buscar e selecionar os idosos cadastrados, organizados por setores e quartos, como ponto central de navegação entre os prontuários digitais. | Agilidade para encontrar o residente e eliminação da fragmentação em múltiplas pranchetas físicas. | OE1 | OE4 |
-| **CP3** | Registro Estruturado de Sinais Vitais e Rotinas de Saúde | Capacidade de coletar e armazenar digitalmente os dados de sinais vitais, alimentação e higiene dos residentes, substituindo o preenchimento manual em papel na beira do leito. | Eliminação do prontuário físico e padronização dos registros assistenciais, com envio seguro ao servidor. | OE1 | OE2 |
-| **CP4** | Consulta e Visualização do Histórico de Registros | Capacidade de exibir o histórico cronológico de aferições e rotinas de saúde de um residente, acessível diretamente no dispositivo móvel. | Suporte imediato à tomada de decisão clínica sem necessidade de consultar arquivos físicos. | OE5 | OE1 |
-| **CP5** | Operação Assistencial Offline com Sincronização Automática | Capacidade do sistema de registrar dados localmente no dispositivo sem conectividade e sincronizá-los automaticamente com o servidor ao restabelecer a rede. | Continuidade da operação assistencial independente da infraestrutura de rede da instituição. | OE3 | OE2 |
-| **CP6** | Gerenciamento Centralizado dos Dados Assistenciais | Capacidade do sistema de receber, validar, organizar e centralizar em repositório único todos os registros coletados pelos dispositivos móveis da equipe. | Eliminação do retrabalho de dupla digitação e criação de base de dados estruturada para relatórios e conformidade regulatória. | OE2 | OE5 |
+| ID | Característica do Produto (CP) | Descrição resumida | OE |
+| --- | --- | --- | --- |
+| **CP1** | Gestão de Residentes | Capacidade de cadastrar, editar e inativar o perfil digital dos residentes atendidos pela instituição. | OE1 |
+| **CP2** | Registro Assistencial Digital | Capacidade de registrar digitalmente, no ponto de cuidado, os dados de sinais vitais, rotinas assistenciais, administração de medicamentos e ocorrências clínicas dos residentes. | OE1 |
+| **CP3** | Autenticação de Usuários | Capacidade de autenticar e encerrar a sessão de membros da equipe, controlando o acesso ao sistema. | OE2 |
+| **CP4** | Gerenciamento de Usuários | Capacidade de cadastrar, atualizar, redefinir senha e revogar o acesso dos membros da equipe assistencial. | OE2 |
+| **CP5** | Consulta do Histórico Assistencial | Capacidade de consultar, filtrar e visualizar o histórico cronológico de registros assistenciais dos residentes, apoiando decisões clínicas da equipe multidisciplinar. | OE3 |
 
 ## 2.4 Tecnologias a Serem Utilizadas
 Para atender às restrições de custo, viabilizar o funcionamento em rede local instável (offline-first) e garantir que o código-fonte seja leve e de fácil manutenção futura por parte da equipe do cliente, o projeto Vital Tech adotará a arquitetura de Progressive Web App (PWA) em conjunto com uma API leve, utilizando as seguintes tecnologias:
@@ -89,6 +86,7 @@ Ao adotar o deploy On-Premise, a solução isola o tráfego de informações na 
 | 10/04/2026 | 1.1 | Finalização e correção do documento para primeira entrega (Seções 1 a 6) para submissão. | Alberto Côrtes, Ana Caroline, Enzo Menali e Gustavo Xavier |
 |13/04/2026 | 1.2 | Lançamento dessa seção no GitPages | Gustavo Xavier |
 |05/05/2026 | 1.3 | Reformulação da seção 2.3 (Características de Produto): adequação ao feedback do professor, remoção de RNFs disfarçados de CPs (antigas CP4 e CP7), substituição por capacidades funcionais derivadas dos OEs revisados. | Gustavo Xavier |
+| 17/05/2026 | 1.4 | Reestruturação completa das seções 2.1, 2.2 e 2.3: reformulação do OG, redução de 5 para 3 OEs e de 6 para 5 CPs com mapeamento 1:1 entre CP e OE. Adição das Regras de Negócio (RN-01 a RN-04). | Gustavo Xavier |
 
 
 ---

--- a/docs/visao/user_stories.md
+++ b/docs/visao/user_stories.md
@@ -1,0 +1,167 @@
+# User Stories e Critérios de Aceitação — VitalTech
+
+As user stories abaixo foram derivadas dos Requisitos Funcionais (RF01–RF16), organizadas na ordem cronológica do Story Map (CP3 → CP4 → CP1 → CP2 → CP5). Cada história inclui critérios de aceitação no formato **Dado / Quando / Então**.
+
+**Personas:**
+- **Gestor** — administração da instituição, gestão de usuários e cadastros base.
+- **Cuidador** — prestação de cuidado direto aos residentes durante o turno.
+- **Membro da equipe multidisciplinar** — enfermeiro, médico, nutricionista ou fisioterapeuta que consulta dados para tomada de decisão clínica.
+
+---
+
+## CP3 — Autenticação de Usuários
+
+### US08 — Autenticar usuário no sistema
+> Como **Cuidador**, quero autenticar meu acesso ao sistema com minhas credenciais individuais, para que apenas membros autorizados possam registrar e consultar dados assistenciais.
+
+**Critérios de Aceitação:**
+- **CA08.1** — Dado que o usuário está na tela de login, quando informar login e senha corretos e confirmar, então o sistema libera o acesso e direciona para a tela inicial.
+- **CA08.2** — Dado que o usuário informa credenciais incorretas, quando tenta confirmar, então o sistema exibe mensagem de erro genérica sem revelar qual campo está incorreto, e o acesso é negado.
+
+---
+
+### US09 — Encerrar sessão do usuário
+> Como **Cuidador**, quero encerrar minha sessão no sistema ao final do turno, para garantir que nenhum outro usuário acesse o sistema em meu nome no dispositivo compartilhado.
+
+**Critérios de Aceitação:**
+- **CA09.1** — Dado que o usuário está autenticado, quando clicar em "Encerrar sessão", então a sessão é encerrada e o usuário é redirecionado para a tela de login.
+- **CA09.2** — Dado que a sessão foi encerrada, quando outro usuário acessar o dispositivo, então os dados da sessão anterior não estão mais visíveis nem acessíveis.
+
+---
+
+## CP4 — Gerenciamento de Usuários
+
+### US10 — Cadastrar usuário
+> Como **Gestor**, quero cadastrar novos usuários na plataforma, para que cada membro da equipe tenha acesso individual ao sistema com suas credenciais próprias.
+
+**Critérios de Aceitação:**
+- **CA10.1** — Dado que o Gestor está autenticado, quando preencher os campos obrigatórios (nome completo, login, perfil e senha provisória) e confirmar, então o novo usuário é criado e pode se autenticar com as credenciais definidas.
+- **CA10.2** — Dado que o Gestor tenta cadastrar um login já existente no sistema, quando confirmar, então o sistema exibe mensagem de erro indicando que o login já está em uso e não realiza o cadastro.
+
+---
+
+### US11 — Atualizar dados cadastrais do usuário
+> Como **Gestor**, quero atualizar os dados cadastrais de um usuário, para manter as informações da equipe corretas no sistema.
+
+**Critérios de Aceitação:**
+- **CA11.1** — Dado que o Gestor está visualizando o perfil de um usuário ativo, quando alterar um ou mais campos e confirmar, então as informações são atualizadas imediatamente no sistema.
+
+---
+
+### US12 — Redefinir senha de acesso do usuário
+> Como **Gestor**, quero redefinir a senha de acesso de um membro da equipe, para restaurar o acesso de alguém que esqueceu suas credenciais.
+
+**Critérios de Aceitação:**
+- **CA12.1** — Dado que o Gestor selecionou um usuário e definiu uma nova senha provisória, quando confirmar a redefinição, então o usuário consegue autenticar-se com a nova senha.
+- **CA12.2** — Dado que a senha foi redefinida, quando o usuário tenta autenticar com a senha antiga, então o acesso é negado.
+
+---
+
+### US13 — Revogar acesso do usuário
+> Como **Gestor**, quero revogar o acesso de um usuário ao sistema, para garantir que ex-funcionários não possam mais acessar dados dos residentes após o desligamento.
+
+**Critérios de Aceitação:**
+- **CA13.1** — Dado que o Gestor confirmou a revogação de acesso de um usuário, então esse usuário não consegue mais autenticar-se no sistema.
+- **CA13.2** — Dado que o acesso foi revogado, então todos os registros assistenciais realizados por esse usuário são mantidos no histórico, associados à sua identificação.
+
+---
+
+## CP1 — Gestão de Residentes
+
+### US01 — Cadastrar dados do residente
+> Como **Gestor**, quero cadastrar os dados pessoais e clínicos de um novo residente, para que a equipe assistencial tenha acesso ao seu perfil digital a partir da admissão.
+
+**Critérios de Aceitação:**
+- **CA01.1** — Dado que o Gestor está autenticado, quando preencher os campos obrigatórios (nome completo, data de nascimento, CPF, grau de dependência e responsável legal) e confirmar, então o perfil digital do residente é criado e fica disponível para toda a equipe.
+- **CA01.2** — Dado que o Gestor tenta cadastrar sem preencher campos obrigatórios, quando confirmar, então o sistema indica os campos em falta e não realiza o cadastro.
+
+---
+
+### US02 — Editar dados pessoais e clínicos do residente
+> Como **Gestor**, quero editar os dados pessoais e clínicos de um residente já cadastrado, para manter o perfil digital atualizado conforme mudanças em seu estado de saúde ou situação pessoal.
+
+**Critérios de Aceitação:**
+- **CA02.1** — Dado que o Gestor está visualizando o perfil de um residente ativo, quando alterar um ou mais campos e confirmar, então as alterações são salvas e o perfil atualizado fica visível para toda a equipe.
+
+---
+
+### US03 — Inativar o cadastro do residente
+> Como **Gestor**, quero inativar o cadastro de um residente que saiu da instituição, para removê-lo do fluxo operacional ativo sem perder seu histórico assistencial.
+
+**Critérios de Aceitação:**
+- **CA03.1** — Dado que o Gestor confirmou a inativação de um residente, então esse residente deixa de aparecer na lista operacional ativa para os cuidadores.
+- **CA03.2** — Dado que o residente foi inativado, então todo o seu histórico assistencial permanece acessível no sistema para consulta pela equipe multidisciplinar, em conformidade com a RN-03.
+
+---
+
+## CP2 — Registro Assistencial Digital
+
+### US04 — Registrar sinais vitais do residente
+> Como **Cuidador**, quero registrar os sinais vitais de um residente durante o meu turno, para que a equipe de saúde tenha um histórico contínuo e atualizado do seu estado clínico.
+
+**Critérios de Aceitação:**
+- **CA04.1** — Dado que o Cuidador está autenticado e selecionou um residente, quando preencher os campos de sinais vitais (pressão arterial, frequência cardíaca, temperatura e glicemia) e confirmar, então o registro é salvo com data, horário automático e identificação do cuidador.
+- **CA04.2** — Dado que o dispositivo está sem conexão com a rede, quando o Cuidador realiza e confirma o registro, então os dados são salvos localmente e sincronizados automaticamente quando a conexão for restabelecida (conforme RN-01).
+
+---
+
+### US05 — Registrar rotinas assistenciais do residente
+> Como **Cuidador**, quero registrar as rotinas assistenciais (alimentação e higiene) realizadas em um residente, para documentar digitalmente o cuidado prestado em substituição ao formulário em papel.
+
+**Critérios de Aceitação:**
+- **CA05.1** — Dado que o Cuidador está autenticado e selecionou um residente, quando registrar as rotinas do turno (alimentação: tipo de refeição e percentual de aceitação; higiene: banho, troca, cuidados bucais) e confirmar, então o registro é salvo com data, horário automático e identificação do cuidador.
+- **CA05.2** — Dado que o dispositivo está sem conexão, quando o registro for salvo, então os dados são retidos localmente e sincronizados ao restabelecer a rede (conforme RN-01).
+
+---
+
+### US06 — Registrar administração de medicamentos
+> Como **Cuidador**, quero registrar a administração de medicamentos a um residente, para garantir o rastreamento correto da medicação efetivamente administrada em cada turno.
+
+**Critérios de Aceitação:**
+- **CA06.1** — Dado que o Cuidador está autenticado e selecionou um residente, quando confirmar a administração de um medicamento, então o registro é salvo com nome do medicamento, horário de administração e identificação do cuidador.
+- **CA06.2** — Dado que o residente recusou ou não pôde receber o medicamento, quando o Cuidador registrar a não administração com o motivo, então a ocorrência é salva e associada ao histórico do turno.
+
+---
+
+### US07 — Registrar ocorrências clínicas do residente
+> Como **Cuidador**, quero registrar ocorrências clínicas observadas em um residente durante o turno, para documentar eventos relevantes que precisam de atenção ou notificação à equipe.
+
+**Critérios de Aceitação:**
+- **CA07.1** — Dado que o Cuidador está autenticado e selecionou um residente, quando selecionar uma ou mais ocorrências da lista padronizada e/ou preencher o campo "Outros (especificar)" e confirmar, então o registro é salvo com data, horário e identificação do cuidador.
+- **CA07.2** — Dado que a ocorrência registrada é "Queda" ou "Tentativa de suicídio", quando o registro for salvo, então o sistema sinaliza que o evento é um caso sentinela e requer notificação à autoridade sanitária, conforme a RN-04.
+
+---
+
+## CP5 — Consulta do Histórico Assistencial
+
+### US14 — Consultar histórico de registros do residente
+> Como **Membro da equipe multidisciplinar**, quero consultar o histórico cronológico de registros de um residente, para acompanhar a evolução clínica e embasar decisões de intervenção.
+
+**Critérios de Aceitação:**
+- **CA14.1** — Dado que o usuário está autenticado e selecionou um residente, quando acessar o histórico assistencial, então o sistema exibe a lista de todos os registros em ordem cronológica decrescente (mais recente primeiro), com data, horário, tipo de registro e nome do cuidador responsável.
+
+---
+
+### US15 — Filtrar histórico por período
+> Como **Membro da equipe multidisciplinar**, quero filtrar o histórico assistencial de um residente por período, para localizar registros específicos e analisar a evolução em um intervalo de tempo determinado.
+
+**Critérios de Aceitação:**
+- **CA15.1** — Dado que o usuário está visualizando o histórico de um residente, quando definir uma data de início e uma data de fim e aplicar o filtro, então o sistema exibe apenas os registros dentro do intervalo selecionado, mantendo a ordenação cronológica.
+- **CA15.2** — Dado que o período filtrado não retorna nenhum registro, quando o filtro for aplicado, então o sistema exibe uma mensagem informando que não há registros no período selecionado.
+
+---
+
+### US16 — Visualizar resumo assistencial do residente
+> Como **Membro da equipe multidisciplinar**, quero visualizar um resumo assistencial consolidado de um residente, para obter rapidamente uma visão geral do seu estado atual antes de uma intervenção ou reunião clínica.
+
+**Critérios de Aceitação:**
+- **CA16.1** — Dado que o usuário está autenticado e selecionou um residente, quando acessar a seção de resumo assistencial, então o sistema exibe o último registro de cada módulo (sinais vitais, rotinas, medicamentos e ocorrências), com data, horário e nome do responsável pelo registro.
+
+---
+
+## Histórico de Revisão
+
+| Data | Versão | Descrição | Autor |
+| :---: | :---: | --- | --- |
+| 17/05/2026 | 1.0 | Criação do documento com US01–US16 derivadas dos RFs revisados (RF01–RF16). | Gustavo Xavier |
+| 17/05/2026 | 1.1 | Adição dos critérios de aceitação (CA) para todas as user stories. Reorganização na ordem cronológica do Story Map (CP3 → CP4 → CP1 → CP2 → CP5). | Gustavo Xavier |


### PR DESCRIPTION
## Resumo das alterações

### solucao_proposta.md
- OG reformulado para frase objetiva
- OEs reduzidos de 5 para 3, com focos declarados
- CPs redefinidas de 6 para 5

### requisitos.md
- RFs consolidados de 30 para 16, cada um com CP única
- Seção de Regras de Negócio adicionada (RN-01 a RN-09)
- RFs antigos que eram RNs foram reclassificados conforme feedback do professor

### Novos arquivos
- `docs/visao/user_stories.md` — 16 user stories com critérios de aceitação (Dado/Quando/Então), na ordem do Story Map
- `docs/visao/dor_dod.md` — Definition of Ready com checklist INVEST
