### PR TITLE
Validação de Cadastro de usuários

### DIFF
--- a/app/frontend/src/services/__tests__/services.test.js
+++ b/app/frontend/src/services/__tests__/services.test.js
@@ -596,6 +596,168 @@ describe('Regressao Sprint 2 - integracao entre cadastro, login e backend', () =
   });
 });
 
+describe('Sprint 4 services - persistencia e validacao de cadastros', () => {
+  it('atualiza usuario preservando senha, login funcional e metadados de rastreabilidade', async () => {
+    const { authService, storage, usuarioService } = createServices();
+    await authService.login({ login: 'gestor', senha: '123456' });
+
+    const usuario = await usuarioService.criarUsuario({
+      nomeCompleto: 'Ana Cadastro',
+      login: 'ana-cadastro',
+      perfil: PERFIS.CUIDADOR,
+      senhaProvisoria: 'senha123',
+      especialidade: 'Cuidados Gerais',
+    });
+
+    const atualizado = await usuarioService.atualizarUsuario(usuario.id, {
+      nomeCompleto: 'Ana Cadastro Atualizada',
+      login: 'ana-atualizada',
+      perfil: 'Equipe',
+      especialidade: 'Fisioterapia',
+      registro: 'CREFITO-999',
+    });
+
+    assert.equal(atualizado.nomeCompleto, 'Ana Cadastro Atualizada');
+    assert.equal(atualizado.login, 'ana-atualizada');
+    assert.equal(atualizado.perfil, PERFIS.MULTIDISCIPLINAR);
+    assert.equal(atualizado.senhaProvisoria, 'senha123');
+    assert.equal(atualizado.createdBy, 'usr_gestor');
+    assert.equal(atualizado.updatedBy, 'usr_gestor');
+    assert.ok(atualizado.updatedAt);
+    assert.equal((await storage.findBy('usuarios', 'login', 'ana-atualizada')).id, usuario.id);
+
+    await authService.logout();
+    const session = await authService.login({
+      login: 'ana-atualizada',
+      senha: 'senha123',
+    });
+
+    assert.equal(session.user.perfil, PERFIS.MULTIDISCIPLINAR);
+  });
+
+  it('bloqueia atualizacao de usuario com login duplicado ou perfil sem permissao', async () => {
+    const { authService, storage, usuarioService } = createServices();
+    await authService.login({ login: 'gestor', senha: '123456' });
+
+    const primeiro = await usuarioService.criarUsuario({
+      nomeCompleto: 'Primeiro Usuario',
+      login: 'primeiro',
+      perfil: PERFIS.CUIDADOR,
+      senhaProvisoria: '123',
+    });
+    const segundo = await usuarioService.criarUsuario({
+      nomeCompleto: 'Segundo Usuario',
+      login: 'segundo',
+      perfil: PERFIS.CUIDADOR,
+      senhaProvisoria: '123',
+    });
+
+    await assert.rejects(
+      () => usuarioService.atualizarUsuario(segundo.id, { login: primeiro.login }),
+      (error) => error instanceof ServiceError
+        && error.code === ERROR_CODES.DUPLICATE_LOGIN,
+    );
+    assert.equal((await storage.get('usuarios', segundo.id)).login, 'segundo');
+
+    await assert.rejects(
+      () => usuarioService.atualizarUsuario(segundo.id, { nomeCompleto: '' }),
+      (error) => error instanceof ServiceError
+        && error.code === ERROR_CODES.REQUIRED_FIELDS
+        && error.details.missingFields.includes('nomeCompleto'),
+    );
+    assert.equal((await storage.get('usuarios', segundo.id)).nomeCompleto, 'Segundo Usuario');
+
+    await assert.rejects(
+      () => usuarioService.atualizarUsuario(segundo.id, {
+        nomeCompleto: 'Tentativa sem permissao',
+      }, CUIDADOR_ATOR),
+      (error) => error instanceof ServiceError
+        && error.code === ERROR_CODES.FORBIDDEN,
+    );
+  });
+
+  it('atualiza residente preservando vinculo com registros assistenciais', async () => {
+    const { authService, residenteService, storage } = createServices();
+    await authService.login({ login: 'gestor', senha: '123456' });
+
+    const residente = await residenteService.criarResidente({
+      nomeCompleto: 'Dona Celia',
+      dataNascimento: '1941-02-03',
+      cpf: '11122233344',
+      grauDependencia: 'II',
+      responsavelLegal: 'Carlos Celia',
+      setor: 'A',
+      quarto: '10',
+    });
+    await storage.put('sinaisVitais', {
+      id: 'sv_residente_editado',
+      residenteId: residente.id,
+      tipoRegistro: 'sinais_vitais',
+    });
+
+    const atualizado = await residenteService.atualizarResidente(residente.id, {
+      nomeCompleto: 'Dona Celia Atualizada',
+      dataNascimento: '1941-02-03',
+      cpf: '111.222.333-44',
+      grauDependencia: 'III',
+      responsavelLegal: 'Carlos Celia',
+      dadosClinicos: 'Hipertensao controlada',
+    });
+
+    assert.equal(atualizado.nomeCompleto, 'Dona Celia Atualizada');
+    assert.equal(atualizado.cpf, '11122233344');
+    assert.equal(atualizado.grauDependencia, 'III');
+    assert.equal(atualizado.updatedBy, 'usr_gestor');
+    assert.ok(atualizado.updatedAt);
+    assert.equal(
+      (await storage.get('sinaisVitais', 'sv_residente_editado')).residenteId,
+      residente.id,
+    );
+  });
+
+  it('bloqueia atualizacao de residente com campo obrigatorio vazio, CPF duplicado ou perfil sem permissao', async () => {
+    const { authService, residenteService, storage } = createServices();
+    await authService.login({ login: 'gestor', senha: '123456' });
+
+    const primeiro = await residenteService.criarResidente({
+      nomeCompleto: 'Dona Laura',
+      dataNascimento: '1940-01-01',
+      cpf: '11111111111',
+      grauDependencia: 'I',
+      responsavelLegal: 'Responsavel Laura',
+    });
+    const segundo = await residenteService.criarResidente({
+      nomeCompleto: 'Dona Marta',
+      dataNascimento: '1942-02-02',
+      cpf: '22222222222',
+      grauDependencia: 'II',
+      responsavelLegal: 'Responsavel Marta',
+    });
+
+    await assert.rejects(
+      () => residenteService.atualizarResidente(segundo.id, { nomeCompleto: '' }),
+      (error) => error instanceof ServiceError
+        && error.code === ERROR_CODES.REQUIRED_FIELDS
+        && error.details.missingFields.includes('nomeCompleto'),
+    );
+    assert.equal((await storage.get('residentes', segundo.id)).nomeCompleto, 'Dona Marta');
+
+    await assert.rejects(
+      () => residenteService.atualizarResidente(segundo.id, { cpf: primeiro.cpf }),
+      (error) => error instanceof ServiceError
+        && error.code === ERROR_CODES.DUPLICATE_CPF,
+    );
+
+    await assert.rejects(
+      () => residenteService.atualizarResidente(segundo.id, {
+        grauDependencia: 'III',
+      }, CUIDADOR_ATOR),
+      (error) => error instanceof ServiceError
+        && error.code === ERROR_CODES.FORBIDDEN,
+    );
+  });
+});
+
 describe('Sprint 3 services - persistencia dos registros assistenciais', () => {
   it('persiste sinais vitais com residente, data, horario e responsavel automaticos', async () => {
     const { assistenciaService, storage } = createServices({

--- a/app/frontend/src/services/permissions.js
+++ b/app/frontend/src/services/permissions.js
@@ -9,6 +9,7 @@ export const PERFIS = Object.freeze({
 
 export const PERMISSOES = Object.freeze({
   USUARIOS_CREATE: 'usuarios:create',
+  USUARIOS_EDIT: 'usuarios:edit',
   USUARIOS_LIST: 'usuarios:list',
   RESIDENTES_CREATE: 'residentes:create',
   RESIDENTES_LIST: 'residentes:list',
@@ -20,6 +21,7 @@ export const PERMISSOES = Object.freeze({
 const PROFILE_PERMISSIONS = Object.freeze({
   [PERFIS.GESTOR]: [
     PERMISSOES.USUARIOS_CREATE,
+    PERMISSOES.USUARIOS_EDIT,
     PERMISSOES.USUARIOS_LIST,
     PERMISSOES.RESIDENTES_CREATE,
     PERMISSOES.RESIDENTES_LIST,

--- a/app/frontend/src/services/residenteService.js
+++ b/app/frontend/src/services/residenteService.js
@@ -2,7 +2,7 @@ import { ERROR_CODES, ServiceError } from './errors.js';
 import { authService } from './authService.js';
 import { assertPermission, PERMISSOES } from './permissions.js';
 import { defaultStorage } from './storage.js';
-import { assertRequiredFields, generateId, nowIso } from './validation.js';
+import { assertRequiredFields, generateId, normalizeCpf, nowIso } from './validation.js';
 
 const REQUIRED_RESIDENT_FIELDS = [
   'nomeCompleto',
@@ -13,6 +13,33 @@ const REQUIRED_RESIDENT_FIELDS = [
 ];
 const RESIDENTS_API_URL = 'http://localhost:3001/residentes';
 
+function hasField(payload, field) {
+  return Object.prototype.hasOwnProperty.call(payload ?? {}, field);
+}
+
+function remoteIdValue(remoteId) {
+  const numericId = Number(remoteId);
+  return Number.isNaN(numericId) ? remoteId : numericId;
+}
+
+function readRequiredText(payload, original, field, normalizer = (value) => String(value).trim()) {
+  if (!hasField(payload, field)) {
+    return original[field];
+  }
+
+  const value = payload[field];
+  return value === undefined || value === null ? '' : normalizer(value);
+}
+
+function readOptionalText(payload, original, field) {
+  if (!hasField(payload, field)) {
+    return original[field] ?? '';
+  }
+
+  const value = payload[field];
+  return value === undefined || value === null ? '' : String(value).trim();
+}
+
 function mapRemoteResident(remoteResident, existingResident = null) {
   return {
     ...existingResident,
@@ -20,7 +47,7 @@ function mapRemoteResident(remoteResident, existingResident = null) {
     remoteId: String(remoteResident.id),
     nomeCompleto: remoteResident.nome || remoteResident.nomeCompleto || '',
     dataNascimento: remoteResident.dataNascimento || '',
-    cpf: String(remoteResident.cpf || '').trim(),
+    cpf: normalizeCpf(remoteResident.cpf),
     grauDependencia: remoteResident.grauDependencia || '',
     responsavelLegal: remoteResident.responsavelLegal || '',
     dadosClinicos: remoteResident.dadosClinicos || existingResident?.dadosClinicos || '',
@@ -31,6 +58,8 @@ function mapRemoteResident(remoteResident, existingResident = null) {
     isAtivo: remoteResident.isAtivo !== false,
     createdAt: remoteResident.createdAt || existingResident?.createdAt || nowIso(),
     createdBy: remoteResident.createdBy || existingResident?.createdBy || 'backend',
+    updatedAt: remoteResident.updatedAt || existingResident?.updatedAt,
+    updatedBy: remoteResident.updatedBy || existingResident?.updatedBy,
   };
 }
 
@@ -45,7 +74,7 @@ export function createResidenteService({ storage = defaultStorage, getCurrentUse
       assertPermission(currentUser, PERMISSOES.RESIDENTES_CREATE);
       assertRequiredFields(payload, REQUIRED_RESIDENT_FIELDS);
 
-      const cpf = String(payload.cpf).trim();
+      const cpf = normalizeCpf(payload.cpf);
       const duplicate = await storage.findBy('residentes', 'cpf', cpf);
 
       if (duplicate) {
@@ -145,26 +174,63 @@ export function createResidenteService({ storage = defaultStorage, getCurrentUse
         throw new ServiceError(ERROR_CODES.NOT_FOUND, 'Residente não encontrado.');
       }
 
+      const cpf = readRequiredText(payload, residenteOriginal, 'cpf', normalizeCpf);
+      const duplicate = await storage.findBy('residentes', 'cpf', cpf);
+
+      if (duplicate && duplicate.id !== residenteOriginal.id) {
+        throw new ServiceError(
+          ERROR_CODES.DUPLICATE_CPF,
+          'CPF ja cadastrado para outro residente.',
+          { cpf },
+        );
+      }
+
       const residenteEditado = {
         ...residenteOriginal,
-        nomeCompleto: payload.nomeCompleto ? String(payload.nomeCompleto).trim() : residenteOriginal.nomeCompleto,
-        dataNascimento: payload.dataNascimento ? String(payload.dataNascimento).trim() : residenteOriginal.dataNascimento,
-        cpf: payload.cpf ? payload.cpf.replace(/\D/g, '') : residenteOriginal.cpf,
-        grauDependencia: payload.grauDependencia ? String(payload.grauDependencia).trim() : residenteOriginal.grauDependencia,
-        responsavelLegal: payload.responsavelLegal ? String(payload.responsavelLegal).trim() : residenteOriginal.responsavelLegal,
-        dadosClinicos: payload.dadosClinicos !== undefined ? String(payload.dadosClinicos).trim() : residenteOriginal.dadosClinicos,
-        setor: payload.setor !== undefined ? String(payload.setor).trim() : residenteOriginal.setor,
-        quarto: payload.quarto !== undefined ? String(payload.quarto).trim() : residenteOriginal.quarto,
-        medicamentos: payload.medicamentos || residenteOriginal.medicamentos || [],
-        foto: payload.foto !== undefined ? payload.foto : residenteOriginal.foto,
+        nomeCompleto: readRequiredText(payload, residenteOriginal, 'nomeCompleto'),
+        dataNascimento: readRequiredText(payload, residenteOriginal, 'dataNascimento'),
+        cpf,
+        grauDependencia: readRequiredText(payload, residenteOriginal, 'grauDependencia'),
+        responsavelLegal: readRequiredText(payload, residenteOriginal, 'responsavelLegal'),
+        dadosClinicos: readOptionalText(payload, residenteOriginal, 'dadosClinicos'),
+        setor: readOptionalText(payload, residenteOriginal, 'setor'),
+        quarto: readOptionalText(payload, residenteOriginal, 'quarto'),
+        medicamentos: hasField(payload, 'medicamentos')
+          ? (Array.isArray(payload.medicamentos) ? payload.medicamentos : [])
+          : (residenteOriginal.medicamentos || []),
+        foto: hasField(payload, 'foto') ? (payload.foto ?? null) : residenteOriginal.foto,
+        updatedAt: nowIso(),
+        updatedBy: currentUser.id,
       };
 
+      assertRequiredFields(residenteEditado, REQUIRED_RESIDENT_FIELDS);
+
       try {
+        const response = await fetch(`${RESIDENTS_API_URL}?cpf=${encodeURIComponent(cpf)}`);
+
+        if (!response.ok) {
+          throw new Error(`Backend Mock respondeu com HTTP ${response.status}.`);
+        }
+
+        const remoteDuplicates = await response.json();
+        const hasRemoteDuplicate = remoteDuplicates.some((remoteResident) => (
+          String(remoteResident.id) !== String(residenteOriginal.remoteId ?? '')
+        ));
+
+        if (hasRemoteDuplicate) {
+          throw new ServiceError(
+            ERROR_CODES.DUPLICATE_CPF,
+            'CPF ja cadastrado para outro residente.',
+            { cpf },
+          );
+        }
+
         if (residenteEditado.remoteId) {
-          const response = await fetch(`${RESIDENTS_API_URL}/${residenteEditado.remoteId}`, {
+          const updateResponse = await fetch(`${RESIDENTS_API_URL}/${residenteEditado.remoteId}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
+              id: remoteIdValue(residenteEditado.remoteId),
               nome: residenteEditado.nomeCompleto,
               dataNascimento: residenteEditado.dataNascimento,
               cpf: residenteEditado.cpf,
@@ -178,10 +244,20 @@ export function createResidenteService({ storage = defaultStorage, getCurrentUse
               isAtivo: residenteEditado.isAtivo,
               createdAt: residenteEditado.createdAt,
               createdBy: residenteEditado.createdBy,
+              updatedAt: residenteEditado.updatedAt,
+              updatedBy: residenteEditado.updatedBy,
             }),
           });
-          if (!response.ok) {
-            throw new Error(`Backend Mock respondeu com HTTP ${response.status}.`);
+          if (updateResponse.status === 409) {
+            throw new ServiceError(
+              ERROR_CODES.DUPLICATE_CPF,
+              'CPF ja cadastrado para outro residente.',
+              { cpf },
+            );
+          }
+
+          if (!updateResponse.ok) {
+            throw new Error(`Backend Mock respondeu com HTTP ${updateResponse.status}.`);
           }
         }
       } catch (error) {
@@ -204,7 +280,7 @@ export function createResidenteService({ storage = defaultStorage, getCurrentUse
 
         const remoteResidents = await response.json();
         for (const remoteResident of remoteResidents) {
-          const cpf = String(remoteResident.cpf || '').trim();
+          const cpf = normalizeCpf(remoteResident.cpf);
           const existingResident = await storage.findBy('residentes', 'cpf', cpf);
           await storage.put(
             'residentes',

--- a/app/frontend/src/services/usuarioService.js
+++ b/app/frontend/src/services/usuarioService.js
@@ -11,7 +11,35 @@ import {
 } from './validation.js';
 
 const REQUIRED_USER_FIELDS = ['nomeCompleto', 'login', 'perfil', 'senhaProvisoria'];
+const REQUIRED_USER_UPDATE_FIELDS = ['nomeCompleto', 'login', 'perfil'];
 const USERS_API_URL = 'http://localhost:3001/usuarios';
+
+function hasField(payload, field) {
+  return Object.prototype.hasOwnProperty.call(payload ?? {}, field);
+}
+
+function remoteIdValue(remoteId) {
+  const numericId = Number(remoteId);
+  return Number.isNaN(numericId) ? remoteId : numericId;
+}
+
+function readRequiredText(payload, original, field, normalizer = (value) => String(value).trim()) {
+  if (!hasField(payload, field)) {
+    return original[field];
+  }
+
+  const value = payload[field];
+  return value === undefined || value === null ? '' : normalizer(value);
+}
+
+function readOptionalText(payload, original, field) {
+  if (!hasField(payload, field)) {
+    return original[field] ?? '';
+  }
+
+  const value = payload[field];
+  return value === undefined || value === null ? '' : String(value).trim();
+}
 
 function mapRemoteUser(remoteUser, existingUser = null) {
   return {
@@ -28,6 +56,8 @@ function mapRemoteUser(remoteUser, existingUser = null) {
     ativo: remoteUser.ativo !== false,
     createdAt: remoteUser.createdAt || existingUser?.createdAt || nowIso(),
     createdBy: remoteUser.createdBy || existingUser?.createdBy || 'backend',
+    updatedAt: remoteUser.updatedAt || existingUser?.updatedAt,
+    updatedBy: remoteUser.updatedBy || existingUser?.updatedBy,
   };
 }
 
@@ -152,15 +182,130 @@ export function createUsuarioService({ storage = defaultStorage, getCurrentUser 
       return list.filter((u) => u.ativo !== false);
     },
 
+    async buscarPorId(id, actor = null) {
+      const currentUser = await resolveActor(actor);
+      assertPermission(currentUser, PERMISSOES.USUARIOS_LIST);
+      return storage.get('usuarios', id);
+    },
+
     async buscarPorLogin(login, actor = null) {
       const currentUser = await resolveActor(actor);
       assertPermission(currentUser, PERMISSOES.USUARIOS_LIST);
       return storage.findBy('usuarios', 'login', normalizeLogin(login));
     },
 
+    async atualizarUsuario(id, payload, actor = null) {
+      const currentUser = await resolveActor(actor);
+      assertPermission(currentUser, PERMISSOES.USUARIOS_EDIT);
+
+      const usuarioOriginal = await storage.get('usuarios', id);
+      if (!usuarioOriginal) {
+        throw new ServiceError(ERROR_CODES.NOT_FOUND, 'Usuario nao encontrado.');
+      }
+
+      const login = readRequiredText(payload, usuarioOriginal, 'login', normalizeLogin);
+      const perfil = readRequiredText(payload, usuarioOriginal, 'perfil', normalizePerfil);
+      const camposObrigatorios = {
+        nomeCompleto: readRequiredText(payload, usuarioOriginal, 'nomeCompleto'),
+        login,
+        perfil,
+      };
+
+      assertRequiredFields(camposObrigatorios, REQUIRED_USER_UPDATE_FIELDS);
+
+      const duplicate = await storage.findBy('usuarios', 'login', login);
+
+      if (duplicate && duplicate.id !== usuarioOriginal.id) {
+        throw new ServiceError(
+          ERROR_CODES.DUPLICATE_LOGIN,
+          'Login ja esta em uso.',
+          { login },
+        );
+      }
+
+      try {
+        const response = await fetch(`${USERS_API_URL}?login=${encodeURIComponent(login)}`);
+
+        if (!response.ok) {
+          throw new Error(`Backend Mock respondeu com HTTP ${response.status}.`);
+        }
+
+        const remoteDuplicates = await response.json();
+        const hasRemoteDuplicate = remoteDuplicates.some((remoteUser) => (
+          String(remoteUser.id) !== String(usuarioOriginal.remoteId ?? '')
+        ));
+
+        if (hasRemoteDuplicate) {
+          throw new ServiceError(
+            ERROR_CODES.DUPLICATE_LOGIN,
+            'Login ja esta em uso.',
+            { login },
+          );
+        }
+      } catch (error) {
+        if (error instanceof ServiceError) throw error;
+        console.warn('Nao foi possivel validar o login no servidor. Validacao local mantida.', error);
+      }
+
+      const usuarioEditado = {
+        ...usuarioOriginal,
+        nomeCompleto: camposObrigatorios.nomeCompleto,
+        login,
+        perfil,
+        senhaProvisoria: usuarioOriginal.senhaProvisoria,
+        especialidade: readOptionalText(payload, usuarioOriginal, 'especialidade'),
+        registro: readOptionalText(payload, usuarioOriginal, 'registro'),
+        foto: hasField(payload, 'foto') ? (payload.foto ?? null) : usuarioOriginal.foto,
+        ativo: hasField(payload, 'ativo') ? payload.ativo !== false : usuarioOriginal.ativo !== false,
+        updatedAt: nowIso(),
+        updatedBy: currentUser.id,
+      };
+
+      try {
+        if (usuarioEditado.remoteId) {
+          const response = await fetch(`${USERS_API_URL}/${usuarioEditado.remoteId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              id: remoteIdValue(usuarioEditado.remoteId),
+              nome: usuarioEditado.nomeCompleto,
+              login: usuarioEditado.login,
+              perfil: usuarioEditado.perfil,
+              senha: usuarioEditado.senhaProvisoria,
+              especialidade: usuarioEditado.especialidade,
+              registro: usuarioEditado.registro,
+              foto: usuarioEditado.foto,
+              ativo: usuarioEditado.ativo,
+              createdAt: usuarioEditado.createdAt,
+              createdBy: usuarioEditado.createdBy,
+              updatedAt: usuarioEditado.updatedAt,
+              updatedBy: usuarioEditado.updatedBy,
+            }),
+          });
+
+          if (response.status === 409) {
+            throw new ServiceError(
+              ERROR_CODES.DUPLICATE_LOGIN,
+              'Login ja esta em uso.',
+              { login },
+            );
+          }
+
+          if (!response.ok) {
+            throw new Error(`Backend Mock respondeu com HTTP ${response.status}.`);
+          }
+        }
+      } catch (error) {
+        if (error instanceof ServiceError) throw error;
+        console.warn('Nao foi possivel sincronizar a edicao do usuario. Registro atualizado apenas localmente.', error);
+      }
+
+      return storage.put('usuarios', usuarioEditado);
+    },
+
     async inativarUsuario(id, actor = null) {
       const currentUser = await resolveActor(actor);
-      assertPermission(currentUser, PERMISSOES.USUARIOS_CREATE);
+      assertPermission(currentUser, PERMISSOES.USUARIOS_EDIT);
       const usuario = await storage.get('usuarios', id);
       if (!usuario) {
         throw new ServiceError(ERROR_CODES.NOT_FOUND, 'Usuario nao encontrado.');

--- a/app/frontend/src/services/validation.js
+++ b/app/frontend/src/services/validation.js
@@ -4,6 +4,10 @@ export function normalizeLogin(login) {
   return String(login ?? '').trim().toLowerCase();
 }
 
+export function normalizeCpf(cpf) {
+  return String(cpf ?? '').replace(/\D/g, '').trim();
+}
+
 export function normalizePerfil(perfil) {
   const p = String(perfil ?? '').trim().toLowerCase();
   if (p === 'equipe') return 'multidisciplinar';


### PR DESCRIPTION
## Descrição

Implementação da Issue #87 — Persistência e validação de cadastros, contemplando a camada de services para atualização de usuários e residentes planejada para a Sprint 4.

Esta PR faz parte da Dupla A, com foco na integração de persistência e validação das US11 e US02, apoiando a interface de edição de cadastros implementada na issue relacionada.

## Alterações realizadas

- Implementado `atualizarUsuario` no `usuarioService`.
- Implementado `buscarPorId` para usuários.
- Ajustado `atualizarResidente` com validações mais rigorosas.
- Adicionada permissão `usuarios:edit` para edição de usuários.
- Adicionada normalização de CPF.
- Adicionada validação de login duplicado em edição de usuário.
- Adicionada validação de CPF duplicado em edição de residente.
- Preservada a senha provisória do usuário editado.
- Preservados os vínculos do residente com registros assistenciais.
- Adicionados metadados `updatedAt` e `updatedBy` para rastreabilidade.
- Adicionados testes de services para o escopo da Sprint 4.

## User Stories relacionadas

- US11 — Atualizar dados cadastrais do usuário.
- US02 — Editar dados pessoais e clínicos do residente.

## Requisitos relacionados

- RF11 — Atualizar dados cadastrais do usuário.
- RF02 — Editar dados pessoais e clínicos do residente.
- RNF01 — Integridade e preservação dos dados.
- RNF12 — Controle de permissões por perfil.
- RNF13 — Rastreabilidade das ações administrativas.
- RNF14 — Confidencialidade dos dados de usuários e residentes.

## Critérios de aceite

- [x] CA11.1 — Dados cadastrais de usuário podem ser atualizados.
- [x] CA11.2 — Campos obrigatórios inválidos ou vazios impedem a atualização de usuário.
- [x] CA02.1 — Dados pessoais e clínicos de residente podem ser atualizados.
- [x] CA02.2 — Campos obrigatórios inválidos ou vazios impedem a atualização de residente.
- [x] Login duplicado é bloqueado na edição de usuário.
- [x] CPF duplicado é bloqueado na edição de residente.
- [x] Usuários sem permissão não conseguem executar atualizações cadastrais.
- [x] A edição de usuário não impede login posterior.
- [x] A edição de residente preserva registros assistenciais já vinculados.

## Validações realizadas

- [x] Atualização de usuário com preservação de senha e login funcional.
- [x] Atualização de residente com preservação de vínculo assistencial.
- [x] Bloqueio de login duplicado.
- [x] Bloqueio de CPF duplicado.
- [x] Bloqueio de campos obrigatórios vazios.
- [x] Bloqueio por perfil sem permissão.
- [x] Testes de regressão das funcionalidades existentes.

## Resultados

- `npm.cmd test`: 35 testes aprovados.
- `npm.cmd run build -- --configLoader runner`: concluído com sucesso.

## Definition of Done

- [x] A camada de persistência e validação entregue corresponde ao objetivo da issue #87.
- [x] As atualizações de usuário e residente foram implementadas nos services.
- [x] Os critérios de aceite relacionados à persistência foram verificados.
- [x] Cenários de erro, exceção e validação de campos obrigatórios foram testados.
- [x] RF11, RF02 e RNFs aplicáveis foram considerados.
- [x] O controle de permissões por perfil foi respeitado.
- [x] A edição de usuário não compromete login, perfil ou permissões.
- [x] A edição de residente não compromete registros assistenciais já vinculados.
- [x] A funcionalidade não interfere negativamente em histórias já entregues.
- [x] Código morto, logs de depuração e trechos temporários foram removidos quando aplicável.
- [x] A entrega permanece rastreável às User Stories, requisitos e critérios de aceite relacionados.
- [x] A entrega foi revisada por pelo menos outro membro da equipe.

## Rastreabilidade

- Issue: #87
- Sprint: Sprint 4
- User Stories: US11 e US02
- Requisitos funcionais: RF11 e RF02
- Requisitos não funcionais: RNF01, RNF12, RNF13 e RNF14