### PR TITLE
Filtro do histórico por período:

### DIFF
--- a/app/frontend/src/components/HistoricoAssistencial.vue
+++ b/app/frontend/src/components/HistoricoAssistencial.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { assistenciaService } from '../services'
+import { filtrarHistoricoPorPeriodo, isDataInicialPosterior } from '../utils/date.js'
 import { getServiceErrorMessage } from '../utils/serviceErrors.js'
 
 const props = defineProps({
@@ -17,6 +18,27 @@ const props = defineProps({
 const registros = ref([])
 const carregando = ref(false)
 const errorMessage = ref('')
+const filtroDataInicio = ref('')
+const filtroDataFim = ref('')
+const filtroDataInicioAplicado = ref('')
+const filtroDataFimAplicado = ref('')
+const filtroAplicado = ref(false)
+const filtroErrorMessage = ref('')
+
+const registrosExibidos = computed(() => {
+  if (!filtroAplicado.value) return registros.value
+
+  return filtrarHistoricoPorPeriodo(
+    registros.value,
+    filtroDataInicioAplicado.value,
+    filtroDataFimAplicado.value,
+  )
+})
+
+const contadorTexto = computed(() => {
+  const total = registrosExibidos.value.length
+  return `${total} registro${total === 1 ? '' : 's'}`
+})
 
 async function carregarHistorico() {
   if (!props.residente?.id) {
@@ -41,6 +63,28 @@ function formatarData(data) {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(data ?? ''))
   if (!match) return data || '--'
   return `${match[3]}/${match[2]}/${match[1]}`
+}
+
+function aplicarFiltro() {
+  filtroErrorMessage.value = ''
+
+  if (isDataInicialPosterior(filtroDataInicio.value, filtroDataFim.value)) {
+    filtroErrorMessage.value = 'A data inicial nao pode ser posterior a data final.'
+    return
+  }
+
+  filtroDataInicioAplicado.value = filtroDataInicio.value
+  filtroDataFimAplicado.value = filtroDataFim.value
+  filtroAplicado.value = Boolean(filtroDataInicio.value || filtroDataFim.value)
+}
+
+function limparFiltro() {
+  filtroDataInicio.value = ''
+  filtroDataFim.value = ''
+  filtroDataInicioAplicado.value = ''
+  filtroDataFimAplicado.value = ''
+  filtroAplicado.value = false
+  filtroErrorMessage.value = ''
 }
 
 function detalheRegistro(registro) {
@@ -81,9 +125,17 @@ function detalheRegistro(registro) {
 }
 
 watch(
-  () => [props.residente?.id, props.refreshKey],
-  carregarHistorico,
+  () => props.residente?.id,
+  () => {
+    limparFiltro()
+    carregarHistorico()
+  },
   { immediate: true },
+)
+
+watch(
+  () => props.refreshKey,
+  carregarHistorico,
 )
 </script>
 
@@ -94,7 +146,28 @@ watch(
         <p class="section-label">HISTORICO ASSISTENCIAL</p>
         <h3 class="section-title">Registros do residente</h3>
       </div>
-      <span class="contador">{{ registros.length }} registro{{ registros.length === 1 ? '' : 's' }}</span>
+      <span class="contador">{{ contadorTexto }}</span>
+    </div>
+
+    <form class="filtro-periodo" @submit.prevent="aplicarFiltro">
+      <label class="field">
+        <span>Data inicial</span>
+        <input v-model="filtroDataInicio" type="date" />
+      </label>
+
+      <label class="field">
+        <span>Data final</span>
+        <input v-model="filtroDataFim" type="date" />
+      </label>
+
+      <div class="filtro-acoes">
+        <button class="btn-primary" type="submit">Aplicar filtro</button>
+        <button class="btn-secondary" type="button" @click="limparFiltro">Limpar filtro</button>
+      </div>
+    </form>
+
+    <div v-if="filtroErrorMessage" class="feedback feedback-error" role="alert">
+      {{ filtroErrorMessage }}
     </div>
 
     <div v-if="carregando" class="estado">Carregando historico...</div>
@@ -107,9 +180,13 @@ watch(
       Nao ha registros assistenciais disponiveis para este residente.
     </div>
 
+    <div v-else-if="registrosExibidos.length === 0" class="estado">
+      Nao ha registros no periodo selecionado.
+    </div>
+
     <div v-else class="historico-lista">
       <article
-        v-for="registro in registros"
+        v-for="registro in registrosExibidos"
         :key="`${registro.origem}-${registro.id}`"
         class="historico-item"
         :class="{ alerta: registro.foraDosParametros || registro.tipoRegistro === 'Ocorrência' }"
@@ -166,6 +243,80 @@ watch(
   font-weight: 700;
   padding: 6px 10px;
   white-space: nowrap;
+}
+
+.filtro-periodo {
+  align-items: flex-end;
+  border: 1px solid #edf2f7;
+  border-radius: 10px;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
+  margin-bottom: 12px;
+  padding: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field span {
+  color: #718096;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.field input {
+  border: 1px solid #d1d9e6;
+  border-radius: 8px;
+  color: #1a1a2e;
+  font: inherit;
+  height: 38px;
+  padding: 0 10px;
+}
+
+.filtro-acoes {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-primary,
+.btn-secondary {
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 700;
+  height: 38px;
+  padding: 0 14px;
+  white-space: nowrap;
+}
+
+.btn-primary {
+  background: #3B6FE8;
+  color: #fff;
+}
+
+.btn-secondary {
+  background: #edf2f7;
+  color: #4a5568;
+}
+
+.feedback {
+  border-radius: 8px;
+  font-size: 13px;
+  margin-bottom: 12px;
+  padding: 10px 12px;
+}
+
+.feedback-error {
+  background: #fff5f5;
+  border: 1px solid #feb2b2;
+  color: #c53030;
 }
 
 .estado {
@@ -260,6 +411,19 @@ watch(
 
   .data-hora {
     white-space: normal;
+  }
+
+  .filtro-periodo {
+    grid-template-columns: 1fr;
+  }
+
+  .filtro-acoes {
+    flex-direction: column;
+  }
+
+  .btn-primary,
+  .btn-secondary {
+    width: 100%;
   }
 
   .historico-lista {

--- a/app/frontend/src/services/__tests__/services.test.js
+++ b/app/frontend/src/services/__tests__/services.test.js
@@ -14,7 +14,11 @@ import { createMemorySessionStorage } from '../sessionStorage.js';
 import { createMemoryStorage } from '../storage.js';
 import { createResidenteService } from '../residenteService.js';
 import { createUsuarioService } from '../usuarioService.js';
-import { calcularIdade } from '../../utils/date.js';
+import {
+  calcularIdade,
+  filtrarHistoricoPorPeriodo,
+  isDataInicialPosterior,
+} from '../../utils/date.js';
 
 function createServices({ getNow } = {}) {
   const storage = createMemoryStorage();
@@ -995,5 +999,52 @@ describe('Sprint 3 services - persistencia dos registros assistenciais', () => {
     } finally {
       globalThis.fetch = previousFetch;
     }
+  });
+});
+
+describe('Sprint 4 - filtro do historico por periodo', () => {
+  it('filtra registros dentro do periodo inclusivo preservando a ordem recebida', () => {
+    const historico = [
+      {
+        id: 'ra_22',
+        tipoRegistro: 'Rotina assistencial',
+        data: '2026-06-22',
+        horario: '15:00',
+      },
+      {
+        id: 'sv_20',
+        tipoRegistro: 'Sinais vitais',
+        data: '2026-06-20',
+        horario: '09:00',
+      },
+      {
+        id: 'sv_18',
+        tipoRegistro: 'Sinais vitais',
+        data: '2026-06-18',
+        horario: '08:00',
+      },
+    ];
+    const original = structuredClone(historico);
+
+    const filtrado = filtrarHistoricoPorPeriodo(historico, '2026-06-20', '2026-06-22');
+
+    assert.deepEqual(filtrado.map((registro) => registro.id), ['ra_22', 'sv_20']);
+    assert.deepEqual(historico, original);
+  });
+
+  it('retorna lista vazia quando nao ha registros no periodo selecionado', () => {
+    const historico = [
+      { id: 'sv_1', data: '2026-06-18' },
+      { id: 'ra_1', data: '2026-06-19' },
+    ];
+
+    const filtrado = filtrarHistoricoPorPeriodo(historico, '2026-06-20', '2026-06-22');
+
+    assert.deepEqual(filtrado, []);
+  });
+
+  it('identifica data inicial posterior a data final', () => {
+    assert.equal(isDataInicialPosterior('2026-06-23', '2026-06-22'), true);
+    assert.equal(isDataInicialPosterior('2026-06-22', '2026-06-22'), false);
   });
 });

--- a/app/frontend/src/utils/date.js
+++ b/app/frontend/src/utils/date.js
@@ -1,4 +1,4 @@
-function parseLocalDate(value) {
+export function parseLocalDate(value) {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value ?? ''));
   if (!match) return null;
 
@@ -17,6 +17,43 @@ function parseLocalDate(value) {
   }
 
   return date;
+}
+
+function parseRecordDate(record) {
+  const data = parseLocalDate(record?.data);
+  if (data) return data;
+
+  const fallback = new Date(record?.registradoEm ?? record?.createdAt ?? '');
+  return Number.isNaN(fallback.getTime()) ? null : fallback;
+}
+
+export function isDataInicialPosterior(dataInicio, dataFim) {
+  const inicio = parseLocalDate(dataInicio);
+  const fim = parseLocalDate(dataFim);
+
+  if (!inicio || !fim) return false;
+
+  return inicio.getTime() > fim.getTime();
+}
+
+export function filtrarHistoricoPorPeriodo(registros, dataInicio, dataFim) {
+  const inicio = parseLocalDate(dataInicio);
+  const fim = parseLocalDate(dataFim);
+
+  if (!inicio && !fim) return registros;
+
+  if (inicio) inicio.setHours(0, 0, 0, 0);
+  if (fim) fim.setHours(23, 59, 59, 999);
+
+  return registros.filter((registro) => {
+    const dataRegistro = parseRecordDate(registro);
+    if (!dataRegistro) return false;
+
+    if (inicio && dataRegistro < inicio) return false;
+    if (fim && dataRegistro > fim) return false;
+
+    return true;
+  });
 }
 
 export function calcularIdade(dataNascimento, hoje = new Date()) {


### PR DESCRIPTION
[HistoricoAssistencial.vue (line 28)]: campos de data inicial/final, aplicar/limpar filtro, validação de período inválido, mensagem de período sem registros e lista derivada sem alterar os registros originais.
[date.js (line 39)]: utilitário testável para filtro inclusivo por período.
[services.test.js (line 733)]: testes da Sprint 4 cobrindo período inclusivo, período sem registros e data inicial posterior à final.
Validação executada:
npm.cmd test passou: 32 testes, 0 falhas.
npm.cmd run build passou.


Observação: não encontrei implementação de medicamentos/US06 no app ou mock atual; o filtro usa data/registradoEm, então registros de medicamento entram automaticamente quando forem integrados no mesmo padrão do histórico.